### PR TITLE
hack to allow json responses

### DIFF
--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -140,7 +140,7 @@ function getType (contentType, types) {
   for (var i = 0; i < types.length; i++) {
     var type = types[i]
 
-    if (is.is(contentType, type)) {
+    if (is.is(contentType, type) || type === 'application/json') {
       return type
     }
   }


### PR DESCRIPTION
I can't figure out how to get example `application/json` responses to return without this hack.
