### PR TITLE
Compare body example media type to RAML API media type

### DIFF
--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -137,8 +137,8 @@ function getType (contentType, types) {
   for (var i = 0; i < types.length; i++) {
     var type = types[i]
 
-    if (is.is(contentType, type)) {
+    //if (is.is(contentType, type)) {
       return type
-    }
+    //}
   }
 }

--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -1,6 +1,6 @@
 var is = require('type-is')
 var router = require('osprey-router')
-var _raml;
+var _raml
 
 /**
  * Export the mock server.
@@ -16,7 +16,7 @@ module.exports = ospreyMockServer
 function ospreyMockServer (raml) {
   var app = router()
 
-  _raml = raml;
+  _raml = raml
 
   app.use(createResources(raml.resources))
 

--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -1,5 +1,6 @@
 var is = require('type-is')
 var router = require('osprey-router')
+var _raml;
 
 /**
  * Export the mock server.
@@ -14,6 +15,8 @@ module.exports = ospreyMockServer
  */
 function ospreyMockServer (raml) {
   var app = router()
+
+  _raml = raml;
 
   app.use(createResources(raml.resources))
 
@@ -86,7 +89,7 @@ function handler (method) {
   })
 
   return function (req, res) {
-    var type = getType(req.headers.accept, types)
+    var type = getType(types)
     var body = bodies[type]
 
     res.statusCode = statusCode
@@ -133,12 +136,12 @@ function setHeaders (res, headers) {
  * @param  {Array}  types
  * @return {String}
  */
-function getType (contentType, types) {
+function getType (types) {
   for (var i = 0; i < types.length; i++) {
     var type = types[i]
 
-    //if (is.is(contentType, type)) {
+    if (_raml.mediaType === type) {
       return type
-    //}
+    }
   }
 }


### PR DESCRIPTION
Make sure the mock api endpoint's body example media type is the same as the defined RAML example API's media type.

Currently this only works if you have one mediaType defined for the RAML API.  I couldn't figure out from the RAML specs if you can have more than one mediaType defined.  I don't know how you would deal with an API that would serve multiple media Types like that jukebox example.
