### PR TITLE
Add simulated network delay #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ osprey-mock-service -f api.raml -p 8000
 
 * `-f` Path to the root RAML definition (E.g. `/path/to/api.raml`)
 * `-p` Port number to bind the server locally
+* `--cors` Enable cross origin headers
+* `--simulate-delay` Number of milliseconds delay (default: 1400ms)
+
 
 ### Locally (JavaScript)
 

--- a/bin/osprey-mock-service.js
+++ b/bin/osprey-mock-service.js
@@ -9,16 +9,18 @@ var morgan = require('morgan')
 var argv = require('yargs')
   .usage(
     'Generate an API mock server from a RAML definition.\n\n' +
-    'Usage: $0 -f [file] -p [port number] --cors'
+    'Usage: $0 -f [file] -p [port number] --cors --simulate-delay'
   )
   .demand(['f', 'p'])
   .describe('f', 'Path to the RAML definition')
   .describe('p', 'Port number to bind the proxy')
   .describe('cors', 'Enable CORS with the API')
+  .describe('simulate-delay', 'Simulate slow network condition. Default 1400ms')
   .argv
 
 var options = {
-  cors: !!argv.cors
+  cors: !!argv.cors,
+  delay: argv.simulateDelay
 }
 
 mock.loadFile(argv.f, options)

--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -11,6 +11,16 @@ module.exports.createServerFromBaseUri = createServerFromBaseUri
 module.exports.loadFile = loadFile
 
 /**
+ * Default network delay duration ms
+ */
+var DEFAULT_DELAY = 1400
+
+/**
+ * Options reference variable
+ */
+var args
+
+/**
  * Create an Osprey server instance.
  *
  * @param  {Object}   raml
@@ -61,6 +71,7 @@ function createServerFromBaseUri (raml, options) {
  * @return {Function}
  */
 function loadFile (filename, options) {
+  args = options
   return require('raml-parser')
     .loadFile(filename)
     .then(function (raml) {
@@ -100,13 +111,14 @@ function handler (method) {
 
     if (type) {
       res.setHeader('Content-Type', type)
+    }
 
+    simulateDelay(function () {
       if (body && body.example) {
         res.write(body.example)
       }
-    }
-
-    res.end()
+      res.end()
+    })
   }
 }
 
@@ -130,4 +142,17 @@ function setHeaders (res, headers) {
   Object.keys(headers).forEach(function (key) {
     res.setHeader(key, headers[key])
   })
+}
+
+/**
+ * Simulate Delayed response
+ *
+ * @param  {Function} fn
+ */
+function simulateDelay (fn) {
+  if (!args.delay) {
+    return fn()
+  }
+  var delay = typeof args.delay === 'number' ? args.delay : DEFAULT_DELAY
+  setTimeout(fn, delay)
 }


### PR DESCRIPTION
Use `setTimeout` to delay `res.write` & `res.end` calls

Created global `args` var as to use it within the handler.  I'm only using the cli, but don't this should affect any direct usage?