### PR TITLE
Add RAMLVersion option

### DIFF
--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -67,7 +67,7 @@ function loadFile (filename, options) {
       var raml = ramlApi.expand(true).toJSON({
         serializeMetadata: false
       })
-      options["RAMLVersion"] = ramlApi.RAMLVersion()
+      options['RAMLVersion'] = ramlApi.RAMLVersion()
       return createServerFromBaseUri(raml, options)
     })
 }

--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -67,6 +67,7 @@ function loadFile (filename, options) {
       var raml = ramlApi.expand(true).toJSON({
         serializeMetadata: false
       })
+      options["RAMLVersion"] = ramlApi.RAMLVersion()
       return createServerFromBaseUri(raml, options)
     })
 }


### PR DESCRIPTION
All the way down at https://github.com/mulesoft-labs/osprey-method-handler/blob/master/osprey-method-handler.js#L422 when the validate function is created, it expects to find the RAML version of the document at options.RAMLVersion. However, this option is never set, returning undefined. 
Therefore, later on, here: https://github.com/mulesoft-labs/node-raml-validate/blob/master/raml-validate.js#L361 the raml validator will default to version 0.8. 
I was trying to run an mock based on a RAML 1.0 document, and although it mostly worked, it couldn't handle array data types, throwing an error that looked like this:

{
  "errors": [
    {
      "type": "json",
      "dataPath": "preferencias",
      "keyword": "repeat",
      "schema": false,
      "data": [
        "a",
        "b"
      ],
      "message": "invalid json (repeat, false)"
    }
  ],
  "stack": "BadRequestError: Request failed to validate against RAML definition\n    at createValidationError (/usr/lib/node_modules/osprey-mock-service/node_modules/osprey/node_modules/osprey-method-handler/osprey-method-handler.js:742:14)\n    at ospreyJsonBody (/usr/lib/node_modules/osprey-mock-service/node_modules/osprey/node_modules/osprey-method-handler/osprey-method-handler.js:455:21)\n    at handle (/usr/lib/node_modules/osprey-mock-service/node_modules/osprey/node_modules/compose-middleware/lib/index.js:56:16)\n    at dispatch (/usr/lib/node_modules/osprey-mock-service/node_modules/osprey/node_modules/compose-middleware/lib/index.js:39:20)\n    at next (/usr/lib/node_modules/osprey-mock-service/node_modules/osprey/node_modules/compose-middleware/lib/index.js:37:24)\n    at /usr/lib/node_modules/osprey-mock-service/node_modules/osprey/node_modules/body-parser/lib/read.js:129:5\n    at invokeCallback (/usr/lib/node_modules/osprey-mock-service/node_modules/osprey/node_modules/body-parser/node_modules/raw-body/index.js:262:16)\n    at done (/usr/lib/node_modules/osprey-mock-service/node_modules/osprey/node_modules/body-parser/node_modules/raw-body/index.js:251:7)\n    at IncomingMessage.onEnd (/usr/lib/node_modules/osprey-mock-service/node_modules/osprey/node_modules/body-parser/node_modules/raw-body/index.js:307:7)\n    at emitNone (events.js:67:13)"
}

After this fix, it now correctly handles the document as a RAML 1.0 one, and the mockup works correctly