### PR TITLE
Allow response header to use example when default is not specified

### DIFF
--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -90,6 +90,8 @@ function handler (method) {
     var value = headers[key]
     if (value && value.default) {
       headers[key] = value.default
+    } else if (value && value.example) {
+      headers[key] = value.example
     }
   })
 

--- a/test/fixtures/example10.raml
+++ b/test/fixtures/example10.raml
@@ -14,6 +14,19 @@ baseUri: http://example.com/api
             example:
               success: true
 
+/header2:
+  get:
+    responses:
+      200:
+        headers:
+          Location:
+            description: This is the new location
+            example: /test
+        body:
+          application/json:
+            example:
+              success: true
+
 /nested:
   get:
     responses:

--- a/test/test10.js
+++ b/test/test10.js
@@ -41,6 +41,21 @@ describe('osprey mock service v1.0', function () {
       })
     })
 
+    it('should respond with example header', function () {
+      return popsicle.default(
+        {
+          method: 'GET',
+          url: '/api/header2'
+        }
+      )
+      .use(server(http))
+      .then(function (res) {
+        expect(res.headers.location).to.equal('/test')
+        expect(JSON.parse(res.body)).to.deep.equal({success: true})
+        expect(res.status).to.equal(200)
+      })
+    })
+
     it('should respond with nested example parameter', function () {
       return popsicle.default(
         {


### PR DESCRIPTION
When a default value is not specified for a header, the example value should be used, if specified.

Fixes #40 

