### PR TITLE
Handle absent options object when loading file.

### DIFF
--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -61,6 +61,7 @@ function createServerFromBaseUri (raml, options) {
  * @return {Function}
  */
 function loadFile (filename, options) {
+  options = options || {}
   return require('raml-1-parser')
     .loadRAML(filename, { rejectOnErrors: true })
     .then(function (ramlApi) {


### PR DESCRIPTION
Discovered this bug by running the code in `example` directory.