### PR TITLE
JSON-encode non strings

### DIFF
--- a/osprey-mock-service.js
+++ b/osprey-mock-service.js
@@ -117,7 +117,7 @@ function handler (method) {
       }
 
       if (example) {
-        res.write(typeof example === 'object' ? JSON.stringify(example) : example)
+        res.write(typeof example !== 'string' ? JSON.stringify(example) : example)
       }
     }
 

--- a/test/fixtures/example10.raml
+++ b/test/fixtures/example10.raml
@@ -24,6 +24,15 @@ baseUri: http://example.com/api
               nested:
                 success: true
 
+/boolean:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: boolean
+            example: true
+
 /examples:
   get:
     responses:

--- a/test/test10.js
+++ b/test/test10.js
@@ -55,6 +55,20 @@ describe('osprey mock service v1.0', function () {
       })
     })
 
+    it('should respond with a boolean body', function () {
+      return popsicle.default(
+        {
+          method: 'GET',
+          url: '/api/boolean'
+        }
+      )
+      .use(server(http))
+      .then(function (res) {
+        expect(JSON.parse(res.body)).to.equal(true)
+        expect(res.status).to.equal(200)
+      })
+    })
+
     it('should respond with multiple examples', function () {
       return popsicle.default(
         {


### PR DESCRIPTION
Fixes #44 

All non-string values can be passed to JSON.stringify when being returned. This is useful for boolean and null values.